### PR TITLE
Allow <Code> tags to use all languages that prism supports

### DIFF
--- a/example/src/app.scss
+++ b/example/src/app.scss
@@ -524,7 +524,7 @@ code[class*="language-"], pre[class*="language-"] {
 .block-code {
   display: block;
   padding: get('rhythm') / 2;
-  color: get('white');
+  //color: get('white');
   margin-top: 0;
 
   @include breakpoint(get('large')) {

--- a/example/src/components/CodeExamples.js
+++ b/example/src/components/CodeExamples.js
@@ -40,7 +40,7 @@ import 'prismjs/components/prism-sql.js';
 import { Code } from 'watson-react-components';
 `}
             </Code>
-            <p>See the PrismJS website for a list of <a href="http://prismjs.com/#languages-list">available languages</a>.</p>
+            <p>See the PrismJS website for a list of <a className="base--a" href="http://prismjs.com/#languages-list">available languages</a>.</p>
 
           </div>
         </div>

--- a/example/src/components/CodeExamples.js
+++ b/example/src/components/CodeExamples.js
@@ -10,7 +10,7 @@ export default function CodeExamples() {
         <h2 className="base--h2">Code</h2>
         <div className="row">
           <div className="block-example">
-            <Code type="markup">
+            <Code language="html">
 {`<div>
   <ul>
     <li> foo </li>
@@ -18,10 +18,11 @@ export default function CodeExamples() {
   </ul>
 </div>`}
             </Code>
+
           </div>
           <div className="block-code">
-            <Code type="jsx">
-{`<Code type="json">
+            <Code language="jsx">
+{`<Code language="html">
 {\`<div>
   <ul>
     <li> foo </li>
@@ -30,6 +31,17 @@ export default function CodeExamples() {
 </div>\`}
 </Code>
 `}</Code>
+            <p>The following languages are automatically included:</p>
+            <code>{Code.languages.join(', ')}</code>
+            <p>To include an additional language, import it <b>before</b> importing <code>watson-react-components</code>:</p>
+            <Code language="js">
+{`import 'prismjs';
+import 'prismjs/components/prism-sql.js';
+import { Code } from 'watson-react-components';
+`}
+            </Code>
+            <p>See the PrismJS website for a list of <a href="http://prismjs.com/#languages-list">available languages</a>.</p>
+
           </div>
         </div>
       </div>

--- a/src/components/Code.js
+++ b/src/components/Code.js
@@ -1,33 +1,40 @@
 import React, { PropTypes } from 'react';
 
 import { PrismCode } from 'react-prism';
-import 'prismjs/prism.js';
+import Prism from 'prismjs';
 import 'prismjs/components/prism-jsx.js';
+import 'prismjs/components/prism-json.js';
+
+// these aren't actually languages:
+const nonlangs = {
+  extend: true,
+  insertBefore: true,
+  DFS: true,
+};
+
+const languages = Object.keys(Prism.languages).filter(lang => !nonlangs[lang]);
 
 export default class CodeBlock extends React.Component {
 
+  static languages = languages;
+
   static propTypes = {
     children: PropTypes.string,
-    type: PropTypes.string,
-  }
+    language: PropTypes.oneOf(languages),
+    type: PropTypes.string, // for backwards compatibility - don't use this
+  };
 
   static defaultProps = {
-    type: 'js',
-  }
-
-  types = {
-    js: 'javascript',
-    jsx: 'jsx',
-    json: 'json',
-    html: 'html',
-    markup: 'markup',
-  }
+    language: 'js',
+  };
 
   render() {
+    const lang = this.props.type || this.props.language;
+
     return (
       <div className="code-block--code">
         <pre>
-          <PrismCode className={`base--pre prism language-${this.types[this.props.type]}`}>
+          <PrismCode className={`base--pre prism language-${lang}`}>
             {this.props.children}
           </PrismCode>
         </pre>

--- a/src/components/Code.js
+++ b/src/components/Code.js
@@ -33,8 +33,8 @@ export default class CodeBlock extends React.Component {
 
     return (
       <div className="code-block--code">
-        <pre>
-          <PrismCode className={`base--pre prism language-${lang}`}>
+        <pre className="base--pre">
+          <PrismCode className={`prism language-${lang}`}>
             {this.props.children}
           </PrismCode>
         </pre>


### PR DESCRIPTION
- Allow `<Code>` tags to use all languages that prism supports
- Rename property from `type` to `language`
- Validate specified language
- Updated example
- Added JSON to default language collection
