### PR TITLE
allow multiple child elements in a tab pane

### DIFF
--- a/src/components/Tabs/Pane.js
+++ b/src/components/Tabs/Pane.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { PropTypes } from 'react';
 
 export default function Pane(props) {
   return (
@@ -9,6 +9,6 @@ export default function Pane(props) {
 }
 
 Pane.propTypes = {
-  label: React.PropTypes.string.isRequired,
-  children: React.PropTypes.element.isRequired,
+  label: PropTypes.string.isRequired,
+  children: PropTypes.oneOfType([PropTypes.array, PropTypes.element]).isRequired,
 };


### PR DESCRIPTION
Without this, react throws an error if you give a pane, for example, two `<p>` elements.
