### PR TITLE
killing .jumbotron--header martin-top

### DIFF
--- a/src/stylesheets/components/jumbotron/_jumbotron.scss
+++ b/src/stylesheets/components/jumbotron/_jumbotron.scss
@@ -21,6 +21,7 @@
 
   &--header {
     line-height: 1;
+    margin-top: 0rem;
   }
 
   &--description {


### PR DESCRIPTION
per James' comment at https://github.com/watson-developer-cloud/document-conversion-nodejs/pull/42#issuecomment-252360169
