### PR TITLE
Dependency cleanup, linting

### DIFF
--- a/dependency-lint.yml
+++ b/dependency-lint.yml
@@ -1,0 +1,60 @@
+# See https://github.com/charlierudolph/dependency-lint/blob/v4.2.0/docs/configuration.md
+# for a detailed explanation of the options
+
+executedModules:
+  npmScripts:
+    dev:
+      - dev
+      - build
+      - prepublish
+      - gh-pages
+      - lint
+      - autofix
+      - validate
+      - test
+  shellScripts:
+    dev: []
+    ignore: []
+    root: ''
+
+ignoreErrors:
+  missing: []
+  shouldBeDependency: []
+  shouldBeDevDependency: []
+  unused:
+    # babel plugins & presets
+    - babel-plugin-*
+    - babel-preset-*
+
+    # browserify plugins
+    - babelify
+    - browserify-global-shim
+    - minifyify
+    - uglifyify
+
+    # eslint parser, plugins, & config
+    - babel-eslint
+    - eslint-plugin-*
+    - eslint-config-*
+
+    # css dependencies
+    - watson-ui-component
+
+requiredModules:
+  files:
+    dev:
+      - '{features,spec,test}/**/*'
+      - '**/*{.,_,-}{spec,test}.js'
+      - 'gulpfile.js'
+      - 'example/src/**/*'
+    ignore:
+      - 'node_modules/**/*'
+      - 'dist/**/*'
+      - 'example/build/**/*'
+    root: '**/*.js'
+  stripLoaders: false
+  transpilers:
+    - extension: .js
+      fnName: transform
+      module: babel-core
+      resultKey: code

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -146,10 +146,7 @@ gulp.task('example-css', () =>
 
 gulp.task('example-js', () =>
   browserify(paths.example_js)
-  .transform('babelify', {
-    presets: ['es2015', 'stage-0', 'react'],
-    plugins: ['transform-object-assign'],
-  }).bundle().on('error', (err) =>
+  .transform('babelify').bundle().on('error', (err) =>
     // eslint-disable-next-line
     console.log('[browserify error]', err.message)
   )

--- a/package.json
+++ b/package.json
@@ -31,12 +31,22 @@
     "node": ">=6",
     "npm": ">=3"
   },
+  "babel": {
+    "presets": [
+      "es2015",
+      "stage-0",
+      "react"
+    ],
+    "plugins": [
+      "transform-object-assign"
+    ]
+  },
   "scripts": {
     "dev": "gulp serve",
     "build": "gulp build",
     "prepublish": "npm run build",
     "gh-pages": "gulp gh-pages",
-    "lint": "eslint .",
+    "lint": "eslint . && dependency-lint",
     "autofix": "eslint --fix .",
     "validate": "npm ls",
     "test": "npm run lint"
@@ -46,9 +56,6 @@
     "react-dom": "ReactDOM"
   },
   "devDependencies": {
-    "babel": "^6.5.2",
-    "babel-cli": "^6.14.0",
-    "babel-core": "^6.14.0",
     "babel-eslint": "^6.1.2",
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-transform-object-assign": "^6.8.0",
@@ -56,10 +63,10 @@
     "babel-preset-react": "^6.11.0",
     "babel-preset-stage-0": "^6.5.0",
     "babelify": "^7.3.0",
-    "breakpoint-sass": "^2.7.0",
     "browser-sync": "^2.14.3",
     "browserify": "^13.1.0",
     "browserify-global-shim": "^1.0.3",
+    "dependency-lint": "^4.2.0",
     "eslint": "^3.3.1",
     "eslint-config-airbnb": "^10.0.1",
     "eslint-plugin-import": "^1.15.0",
@@ -75,30 +82,23 @@
     "gulp-sass": "^2.1.0",
     "gulp-sourcemaps": "^1.6.0",
     "minifyify": "^7.1.0",
-    "modular-scale": "^4.4.1",
-    "modularscale-sass": "^2.1.1",
-    "prismjs": "^1.5.1",
-    "react": "^15.3.1",
-    "react-addons-pure-render-mixin": "^15.3.1",
-    "react-dom": "^15.3.1",
-    "react-prism": "^3.2.1",
+    "react-dom": "~0.14.0 || ~15.3.0",
     "uglifyify": "^3.0.2",
-    "vinyl-source-stream": "^1.1.0",
-    "watson-ui-components": "^0.5.3"
+    "vinyl-source-stream": "^1.1.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",
+    "prismjs": "^1.5.1",
+    "react": "~0.14 || ~15.3.0",
     "react-dropzone": "^3.6.0",
-    "react-radio-group": "^3.0.1"
+    "react-prism": "^4.0.0",
+    "react-radio-group": "^3.0.1",
+    "watson-ui-components": "^0.5.3"
   },
   "peerDependencies": {
-    "breakpoint-sass": "^2.7.0",
-    "modular-scale": "^4.4.1",
-    "modularscale-sass": "^2.1.1",
     "watson-ui-components": "^0.5.3",
     "react": "~0.14 || ~15.3.0",
     "react-dom": "~0.14.0 || ~15.3.0",
-    "prismjs": "^1.5.1",
-    "react-prism": "^3.2.1"
+    "prismjs": "^1.5.1"
   }
 }


### PR DESCRIPTION
Update `dependencies` and `devDependencies` to correctly represent the state of things. 

Once https://github.com/charlierudolph/dependency-lint/issues/37 is fixed, we should be able to add it to autofix also.

Fixes #1, supersedes #15
