### PR TITLE
ButtonsGroup ehnancements

### DIFF
--- a/example/src/App.js
+++ b/example/src/App.js
@@ -26,9 +26,9 @@ export default function App() {
       <JumbotronExamples />
       <TabsExamples />
       <RadioGroupExamples />
+      <ButtonsGroupExamples />
       <CodeExamples />
       <ImagePickerExamples />
-      <ButtonsGroupExamples />
     </div>
   );
 }

--- a/example/src/components/ButtonsGroupExamples.js
+++ b/example/src/components/ButtonsGroupExamples.js
@@ -77,7 +77,7 @@ export default function ButtonsGroupExamples() {
   name="radio-buttons"
   buttons={[{
     value: 1,
-    id: 'radio-buttons-1',  // id's need to be unique
+    id: 'radio-buttons-1',  // id's must be unique across the entire page. Default value is groupName-buttonValue
     text: 'hello',
   }, {
     value: 2,

--- a/example/src/components/ButtonsGroupExamples.js
+++ b/example/src/components/ButtonsGroupExamples.js
@@ -12,6 +12,8 @@ export default function ButtonsGroupExamples() {
           <ButtonsGroup
             type="button"
             name="button"
+            onClick={e => console.log('button clicked', e)}
+            onChange={e => console.log('button changed', e)}
             buttons={[{
               value: 1,
               id: 'button-1',
@@ -30,6 +32,8 @@ export default function ButtonsGroupExamples() {
           <ButtonsGroup
             type="radio"
             name="radio-buttons"
+            onClick={e => console.log('radio clicked', e)}
+            onChange={e => console.log('radio changed', e)}
             buttons={[{
               value: 1,
               id: 'radio-buttons-1',
@@ -48,6 +52,8 @@ export default function ButtonsGroupExamples() {
           <ButtonsGroup
             type="checkbox"
             name="check-buttons"
+            onClick={e => console.log('checkbox clicked', e)}
+            onChange={e => console.log('checkbox changed', e)}
             buttons={[{
               value: 1,
               id: 'check-buttons-1',
@@ -75,9 +81,11 @@ export default function ButtonsGroupExamples() {
 {`<ButtonsGroup
   type="radio"  // radio, button, or checkbox
   name="radio-buttons"
+  onClick={e => console.log('clicked', e)}
+  onChange={e => console.log('changed', e)}
   buttons={[{
     value: 1,
-    id: 'radio-buttons-1',  // id's must be unique across the entire page. Default value is groupName-buttonValue
+    id: 'radio-buttons-1',  // id's must be unique across the entire page. Default value is name-value
     text: 'hello',
   }, {
     value: 2,

--- a/example/src/components/ButtonsGroupExamples.js
+++ b/example/src/components/ButtonsGroupExamples.js
@@ -6,7 +6,7 @@ export default function ButtonsGroupExamples() {
   return (
     <section className="_full-width-row" id="Footer">
       <div className="_container _container_large">
-        <h2 className="base--h2">Footer</h2>
+        <h2 className="base--h2">Buttons Group</h2>
         <div className="row">
           <h5 className="base--h5">Normal Buttons</h5>
           <ButtonsGroup

--- a/src/components/ButtonsGroup/index.js
+++ b/src/components/ButtonsGroup/index.js
@@ -9,7 +9,7 @@ export default class ButtonsGroup extends React.Component {
     minWidth: PropTypes.string, // will be overrided if isExpanded is true
     name: PropTypes.string.isRequired,
     buttons: PropTypes.arrayOf(PropTypes.shape({
-      value: PropTypes.number.isRequired,
+      value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
       id: PropTypes.string,
       text: PropTypes.string.isRequired,
     })),

--- a/src/components/ButtonsGroup/index.js
+++ b/src/components/ButtonsGroup/index.js
@@ -10,8 +10,8 @@ export default class ButtonsGroup extends React.Component {
     name: PropTypes.string.isRequired,
     buttons: PropTypes.arrayOf(PropTypes.shape({
       value: PropTypes.number.isRequired,
-      id: PropTypes.string.isRequired,
-      text: PropTypes.string.isrequired,
+      id: PropTypes.string,
+      text: PropTypes.string.isRequired,
     })),
     onClick: PropTypes.func,
     onChange: PropTypes.func,
@@ -39,7 +39,7 @@ export default class ButtonsGroup extends React.Component {
             <input
               className="base--radio buttons-group--radio"
               type={this.props.type}
-              id={button.id}
+              id={button.id || `${this.props.name}-${button.value}`}
               name={this.props.name}
               value={button.value}
               onClick={this.props.onClick}

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -13,3 +13,4 @@ export Code from './Code';
 export Icon from './Icon';
 
 export { RadioGroup, Radio } from './RadioGroup.js';
+export ButtonsGroup from './ButtonsGroup';


### PR DESCRIPTION
A couple of typos little fixes and improvements. I'd like to go a little further, but I thought I'd create a PR here for discussion first.

@jzhang300 sorry I didn't look very thoroughly at your PR - I really should have mentioned some of these things then :/

What this includes:
- export `ButtonsGroup` in index.js
- typo fixes
- set default IDs
- updated the example a little bit to show onClick/onChange, and reside just below the existing RadioGroup example
- allow string values

Known issues:
- When clicking on a regular button, the click event is sometimes triggered 3 times, with a delay before the second two. I don't have any idea what's causing this...
- Radio Buttons trigger an onChange event even if nothing changed (e.g. you click it twice)

Things I'd like to improve:
- This thing has state, but it's not treated as such. As it currently stands, there's no easy way to, for example, get the list of currently-checked checkboxes. Or reset radio buttons. I think we should either:
  -  Make it stateless (selected values come from the properties, and if the props don't change in response to a click, then the widget doesn't change). We could provide helper functions to take the old state + the clicked item and return a new state for radios or checkboxes. In this version, there is no onChange event because all changes come from above.
  - Or else capture the entire state and include it with any callback function.
  - I'd prefer the stateless option, but either one would work.
- I'd like to see a way to put HTML inside of the buttons. (`<Icon/>`s in particular)
  - Making the buttons their own element instead of passed in objects could accomplish this, and also allow for a few other enhancements - such as onClick's on each button. It would also feel a little more "react-like". If we go this route, we should probably make `<Button>` work as a standalone element as well as inside of a <ButtonGroup />
