### PR TITLE
Add Table of Contents to examples page

### DIFF
--- a/dependency-lint.yml
+++ b/dependency-lint.yml
@@ -5,6 +5,7 @@ executedModules:
   npmScripts:
     dev:
       - dev
+      - start
       - build
       - prepublish
       - gh-pages

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -23,21 +23,25 @@ export default function App() {
     <div>
       <Nav />
       <LeadSpace />
-      <ToC>
-        <GettingStarted />
-        <IconExamples />
-        <HeaderExamples />
-        <FooterExamples />
-        <JumbotronExamples />
-        <TabsExamples />
-        <TextInputExamples />
-        <RadioGroupExamples />
-        <ButtonsGroupExamples />
-        <CodeExamples />
-        <ImagePickerExamples />
-        <AlertExamples />
-        <ModalExamples />
-      </ToC>
+      <div className="_container _container_large">
+        <div className="content--session-container">
+          <ToC>
+            <GettingStarted />
+            <IconExamples />
+            <HeaderExamples />
+            <FooterExamples />
+            <JumbotronExamples />
+            <TabsExamples />
+            <TextInputExamples />
+            <RadioGroupExamples />
+            <ButtonsGroupExamples />
+            <CodeExamples />
+            <ImagePickerExamples />
+            <AlertExamples />
+            <ModalExamples />
+          </ToC>
+        </div>
+      </div>
     </div>
   );
 }

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -3,6 +3,7 @@ import React from 'react';
 import GettingStarted from './internal-components/GettingStarted';
 import LeadSpace from './internal-components/LeadSpace';
 import Nav from './internal-components/Nav';
+import ToC from './internal-components/ToC';
 
 import IconExamples from './components/IconExamples';
 import HeaderExamples from './components/HeaderExamples';
@@ -22,19 +23,21 @@ export default function App() {
     <div>
       <Nav />
       <LeadSpace />
-      <GettingStarted />
-      <IconExamples />
-      <HeaderExamples />
-      <FooterExamples />
-      <JumbotronExamples />
-      <TabsExamples />
-      <TextInputExamples />
-      <RadioGroupExamples />
-      <ButtonsGroupExamples />
-      <CodeExamples />
-      <ImagePickerExamples />
-      <AlertExamples />
-      <ModalExamples />
+      <ToC>
+        <GettingStarted />
+        <IconExamples />
+        <HeaderExamples />
+        <FooterExamples />
+        <JumbotronExamples />
+        <TabsExamples />
+        <TextInputExamples />
+        <RadioGroupExamples />
+        <ButtonsGroupExamples />
+        <CodeExamples />
+        <ImagePickerExamples />
+        <AlertExamples />
+        <ModalExamples />
+      </ToC>
     </div>
   );
 }

--- a/example/src/components/AlertExamples.js
+++ b/example/src/components/AlertExamples.js
@@ -7,13 +7,12 @@ export default function AlertExamples() {
   const colors = ['green', 'yellow', 'blue', 'red', 'red'];
   const types = ['success', 'warning', 'info', 'error', 'error-o'];
   return (
-    <section className="_full-width-row" id="Alert">
-      <div className="_container _container_large">
+    <section>
         <h2 className="base--h2">Alert</h2>
         <div className="row">
           <div className="block-example">
             {types.map((type, index) => (
-              <Alert type={type} color={colors[index]}>
+              <Alert type={type} color={colors[index]} key={`alert-${type}-${index}`}>
                 <p className="base--p">This is <b>{type}</b> box.</p>
               </Alert>
             ))}
@@ -76,7 +75,6 @@ export default function AlertExamples() {
             </Code>
           </div>
         </div>
-      </div>
-    </section>
+      </section>
   );
 }

--- a/example/src/components/ButtonsGroupExamples.js
+++ b/example/src/components/ButtonsGroupExamples.js
@@ -4,8 +4,7 @@ import Code from '../../../src/components/Code';
 
 export default function ButtonsGroupExamples() {
   return (
-    <section className="_full-width-row" id="ButtonsGroup">
-      <div className="_container _container_large">
+    <section>
         <h2 className="base--h2">Buttons Group</h2>
         <div className="row">
           <h5 className="base--h5">Normal Buttons</h5>
@@ -104,7 +103,6 @@ export default function ButtonsGroupExamples() {
   }]}
 />`}
         </Code>
-      </div>
-    </section>
+      </section>
   );
 }

--- a/example/src/components/CodeExamples.js
+++ b/example/src/components/CodeExamples.js
@@ -5,8 +5,7 @@ import Code from '../../../src/components/Code';
 
 export default function CodeExamples() {
   return (
-    <section className="_full-width-row" id="Code">
-      <div className="_container _container_large">
+    <section>
         <h2 className="base--h2">Code</h2>
         <div className="row">
           <div className="block-example">
@@ -44,7 +43,6 @@ import { Code } from 'watson-react-components';
 
           </div>
         </div>
-      </div>
-    </section>
+      </section>
   );
 }

--- a/example/src/components/FooterExamples.js
+++ b/example/src/components/FooterExamples.js
@@ -4,8 +4,7 @@ import Code from '../../../src/components/Code';
 
 export default function FooterExamples() {
   return (
-    <section className="_full-width-row" id="Footer">
-      <div className="_container _container_large">
+    <section>
         <h2 className="base--h2">Footer</h2>
         <div className="row">
           <div>
@@ -17,7 +16,6 @@ export default function FooterExamples() {
 `}</Code>
           </div>
         </div>
-      </div>
-    </section>
+      </section>
   );
 }

--- a/example/src/components/HeaderExamples.js
+++ b/example/src/components/HeaderExamples.js
@@ -4,8 +4,7 @@ import Code from '../../../src/components/Code';
 
 export default function HeaderExamples() {
   return (
-    <section className="_full-width-row" id="Header">
-      <div className="_container _container_large">
+    <section>
         <h2 className="base--h2">Header</h2>
         <div className="row">
           <div>
@@ -28,7 +27,6 @@ export default function HeaderExamples() {
 />`}</Code>
           </div>
         </div>
-      </div>
-    </section>
+      </section>
   );
 }

--- a/example/src/components/IconExamples.js
+++ b/example/src/components/IconExamples.js
@@ -4,8 +4,7 @@ import { Icon } from '../../../src/components/Icon';
 
 export default function IconExamples() {
   return (
-    <section className="_full-width-row" id="Icons">
-      <div className="_container _container_large">
+    <section>
         <h2 className="base--h2">Icons</h2>
         <div className="row">
           <div className="block-example">
@@ -128,7 +127,6 @@ export default function IconExamples() {
             </Code>
           </div>
         </div>
-      </div>
-    </section>
+      </section>
   );
 }

--- a/example/src/components/ImagePickerExamples.js
+++ b/example/src/components/ImagePickerExamples.js
@@ -6,8 +6,7 @@ import Code from '../../../src/components/Code';
 
 export default function ImagePickerExamples() {
   return (
-    <section className="_full-width-row" id="ImagePicker">
-      <div className="_container _container_large">
+    <section>
         <h2 className="base--h2">ImagePicker</h2>
         <ImagePicker />
         <Code language="html">
@@ -57,7 +56,6 @@ export default function ImagePickerExamples() {
   urlError: React.PropTypes.string, // error message on url input
 }`}
         </Code>
-      </div>
-    </section>
+      </section>
   );
 }

--- a/example/src/components/JumbotronExamples.js
+++ b/example/src/components/JumbotronExamples.js
@@ -6,8 +6,7 @@ import Code from '../../../src/components/Code';
 
 export default function JumbotronExamples() {
   return (
-    <section className="_full-width-row" id="Jumbotron">
-      <div className="_container _container_large">
+    <section>
         <h2 className="base--h2">Jumbotron</h2>
         <div className="row">
           <div>
@@ -34,7 +33,6 @@ export default function JumbotronExamples() {
 />`}</Code>
           </div>
         </div>
-      </div>
-    </section>
+      </section>
   );
 }

--- a/example/src/components/JumbotronExamples.js
+++ b/example/src/components/JumbotronExamples.js
@@ -4,7 +4,7 @@ import React from 'react';
 import Jumbotron from '../../../src/components/Jumbotron';
 import Code from '../../../src/components/Code';
 
-export default function HeaderExamples() {
+export default function JumbotronExamples() {
   return (
     <section className="_full-width-row" id="Jumbotron">
       <div className="_container _container_large">

--- a/example/src/components/ModalExamples.js
+++ b/example/src/components/ModalExamples.js
@@ -12,8 +12,7 @@ export default React.createClass({
 
   render() {
     return (
-      <section className="_full-width-row" id="Modal">
-        <div className="_container _container_large">
+      <section>
           <h2 className="base--h2">Modal</h2>
           <div className="row">
             <button
@@ -85,8 +84,7 @@ const onEnter = () => {
 </Modal>
 `}
           </Code>
-        </div>
-      </section>
+        </section>
     );
   },
 });

--- a/example/src/components/RadioGroupExamples.js
+++ b/example/src/components/RadioGroupExamples.js
@@ -38,8 +38,7 @@ const FooBarBazRadio = React.createClass({
 
 export default function RadioGroupExample() {
   return (
-    <section className="_full-width-row" id="RadioButtons">
-      <div className="_container _container_large">
+    <section>
         <h2 className="base--h2">Radio Buttons</h2>
         <div className="row">
           <div className="block-example">
@@ -81,7 +80,6 @@ export default function RadioGroupExample() {
             </Code>
           </div>
         </div>
-      </div>
-    </section>
+      </section>
   );
 }

--- a/example/src/components/TabsExamples.js
+++ b/example/src/components/TabsExamples.js
@@ -7,8 +7,7 @@ import Code from '../../../src/components/Code';
 
 export default function TabsExamples() {
   return (
-    <section className="_full-width-row" id="Tabs">
-      <div className="_container _container_large">
+    <section>
         <h2 className="base--h2">Tabs</h2>
         <div className="row">
           <div className="block-example">
@@ -41,7 +40,6 @@ export default function TabsExamples() {
 </Tabs>`}</Code>
           </div>
         </div>
-      </div>
-    </section>
+      </section>
   );
 }

--- a/example/src/components/TextInputExamples.js
+++ b/example/src/components/TextInputExamples.js
@@ -12,8 +12,7 @@ export default React.createClass({
 
   render() {
     return (
-      <section className="_full-width-row" id="TextInput">
-        <div className="_container _container_large">
+      <section>
           <h2 className="base--h2">Text Input</h2>
           <div className="row">
             <div className="block-example">
@@ -41,8 +40,7 @@ export default React.createClass({
               </Code>
             </div>
           </div>
-        </div>
-      </section>
+        </section>
     );
   },
 });

--- a/example/src/internal-components/GettingStarted.js
+++ b/example/src/internal-components/GettingStarted.js
@@ -4,8 +4,7 @@ import Code from '../../../src/components/Code';
 /* eslint-disable react/jsx-indent */
 export default function GettingStrted() {
   return (
-    <div className="_container _container_large">
-      <div className="content--session-container">
+    <div>
         <h1 id="#getting-started" className="base--h1">Installation</h1>
 
         <h2 className="base--h2">npm</h2>
@@ -41,7 +40,6 @@ export default function GettingStrted() {
           To use components that use images, make sure that the image files are
           correctly referenced in your project relative to the CSS output file.
         </p>
-      </div>
     </div>
   );
 }

--- a/example/src/internal-components/ToC.js
+++ b/example/src/internal-components/ToC.js
@@ -25,26 +25,20 @@ export default function ToC(props) {
     return (
       <div id={id} key={`${id}-anchor`}>
         {c}
-        <div className="_full-width-row">
-          <div className="_container _container_large">
-            <a href="#ToC" style={{ float: 'right' }}>
-              <Icon type="up" size="small" />
-            </a>
-          </div>
-        </div>
+        <a href="#ToC" style={{ float: 'right' }}>
+          <Icon type="up" size="small" />
+        </a>
       </div>
     );
   });
 
   return (
-    <section className="_full-width-row" id="ToC">
-      <div className="_container _container_large">
-        <h2 className="base--h2">Table of Contents</h2>
-        <ul className="base--ul" style={{ paddingLeft: '1em' }}>
-          {tocElements}
-        </ul>
-        {children}
-      </div>
+    <section id="ToC">
+      <h2 className="base--h2">Table of Contents</h2>
+      <ul className="base--ul" style={{ paddingLeft: '1em' }}>
+        {tocElements}
+      </ul>
+      {children}
     </section>
   );
 }

--- a/example/src/internal-components/ToC.js
+++ b/example/src/internal-components/ToC.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import { Icon } from '../../../src/components/Icon';
+
+
+export default function ToC(props) {
+  // the docs mention a displayName property, but I don't see it on most elements.
+  // However, child.type is a reference to the constructor function,
+  // and child.type.name (usually) gives the name of the constructor function
+  // so, that's a good enough fallback for our use case.
+
+  const tocElements = props.children.map(c => {
+    const id = c.type.displayName || c.type.name;
+    return (
+      <li key={`${id}-toc-entry`} className="base--li">
+        <a className="base--a" href={`#${id}`}>
+          { /* add a space before each capital letter in the ID, then drop "Examples" */}
+          {id.replace(/([a-z])([A-Z])/g, '$1 $2').replace(/Examples?$/, '')}
+        </a>
+      </li>
+    );
+  });
+
+  const children = props.children.map(c => {
+    const id = c.type.displayName || c.type.name;
+    return (
+      <div id={id} key={`${id}-anchor`}>
+        {c}
+        <div className="_full-width-row">
+          <div className="_container _container_large">
+            <a href="#ToC" style={{ float: 'right' }}>
+              <Icon type="up" size="small" />
+            </a>
+          </div>
+        </div>
+      </div>
+    );
+  });
+
+  return (
+    <section className="_full-width-row" id="ToC">
+      <div className="_container _container_large">
+        <h2 className="base--h2">Table of Contents</h2>
+        <ul className="base--ul" style={{ paddingLeft: '1em' }}>
+          {tocElements}
+        </ul>
+        {children}
+      </div>
+    </section>
+  );
+}
+
+ToC.propTypes = {
+  children: React.PropTypes.array.isRequired,
+};

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   },
   "scripts": {
     "dev": "gulp serve",
+    "start": "gulp serve",
     "build": "gulp build",
     "prepublish": "npm run build",
     "gh-pages": "gulp gh-pages",


### PR DESCRIPTION
Generated from the names of the examples themselves.

Also fixed a few smaller things (`npm start`, incorrectly-named `JumbotronExamples`, and general divitus)