### PR TITLE
allow custom element and/or contents in JsonLink component

### DIFF
--- a/src/components/JsonLink.js
+++ b/src/components/JsonLink.js
@@ -12,16 +12,16 @@ export default function JsonLink(props) {
   };
 
   return (
-    <div className="results--json">
+    <props.element className="results--json">
       <a
         onClick={handleClick}
         className="json-link base--a"
         rel="noopener noreferrer"
         href
       >
-        <span className="json-link--span">JSON</span> <Icon type="link-out" size="small" fill={Colors.blue_50} />
+        <span className="json-link--span">{props.children || 'JSON'}</span> <Icon type="link-out" size="small" fill={Colors.blue_50} />
       </a>
-    </div>
+    </props.element>
   );
 }
 
@@ -30,4 +30,13 @@ JsonLink.propTypes = {
     React.PropTypes.string,
     React.PropTypes.object,
   ]).isRequired,
+  element: React.PropTypes.string,
+  children: React.PropTypes.oneOfType([
+    React.PropTypes.element,
+    React.PropTypes.arrayOf(React.PropTypes.element),
+  ]),
+};
+
+JsonLink.defaultProps = {
+  element: 'div',
 };


### PR DESCRIPTION
Two new props:

* `element` - which defaults to `div` but could be set to e.g. `span` to allow the component to appear inline
* `contents` - replaces the text 'JSON' if defined. Currently the Icon is still there, because that matches my need, but in the future we could add an additional property to allow hiding it.

This is for the JSON tab of the STT demo - with interim results enabled, that thing dumps tons of JSON. Rather than make the user scroll through all of it in a single giant wall of text, I'm creating summaries and letting the user click them for the complete text:

![screen shot 2016-11-28 at 5 50 50 pm](https://cloud.githubusercontent.com/assets/114976/20689409/4631479c-b593-11e6-92e8-3d9ab5a92a3e.png)
