### PR TITLE
expose colors, add an example

### DIFF
--- a/example/src/App.js
+++ b/example/src/App.js
@@ -16,6 +16,7 @@ import ImagePickerExamples from './components/ImagePickerExamples';
 import ButtonsGroupExamples from './components/ButtonsGroupExamples';
 import AlertExamples from './components/AlertExamples';
 import ArrowBoxExamples from './components/ArrowBoxExamples';
+import ColorsExample from './components/ColorsExample';
 import ModalExamples from './components/ModalExamples';
 import TextInputExamples from './components/TextInputExamples';
 import JsonLinkExamples from './components/JsonLinkExamples';
@@ -42,6 +43,7 @@ export default function App() {
             <AlertExamples />
             <ModalExamples />
             <ArrowBoxExamples />
+            <ColorsExample />
             <JsonLinkExamples />
           </ToC>
         </div>

--- a/example/src/app.scss
+++ b/example/src/app.scss
@@ -543,3 +543,12 @@ code[class*="language-"], pre[class*="language-"] {
   display: block;
   padding: 1rem;
 }
+
+#Colors li {
+  text-align: center;
+  line-height: 100px;
+  height: 100px;
+  width: 100px;
+  margin-bottom: 1rem;
+  display: inline-block;
+}

--- a/example/src/components/ColorsExample.js
+++ b/example/src/components/ColorsExample.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import Colors from '../../../src/components/Colors';
+
+export default function ColorsExamples() {
+  return (
+    <section id="Colors">
+      <h2 className="base--h2">Colors</h2>
+      <div className="row">
+        <ul className="base--ul base--ul_inline base--ul_no-bullets">
+          {Object.keys(Colors).map(c => (<li className="base--li" key={c} style={{
+                  backgroundColor: Colors[c],
+                  // 8947848 is #888888, converted to decimal - darker
+                  color: parseInt(Colors[c].substr(1), 16) > 8947848 ? 'black' : 'white'
+                }}>{c}</li>)
+          )}
+        </ul>
+      </div>
+    </section>
+  );
+}

--- a/example/src/components/ColorsExample.js
+++ b/example/src/components/ColorsExample.js
@@ -1,20 +1,26 @@
 import React from 'react';
+import Code from '../../../src/components/Code';
 import Colors from '../../../src/components/Colors';
 
 export default function ColorsExamples() {
   return (
     <section id="Colors">
       <h2 className="base--h2">Colors</h2>
-      <div className="row">
-        <ul className="base--ul base--ul_inline base--ul_no-bullets">
-          {Object.keys(Colors).map(c => (<li className="base--li" key={c} style={{
-                  backgroundColor: Colors[c],
-                  // 8947848 is #888888, converted to decimal - darker
-                  color: parseInt(Colors[c].substr(1), 16) > 8947848 ? 'black' : 'white'
-                }}>{c}</li>)
-          )}
-        </ul>
-      </div>
+      <ul className="base--ul base--ul_inline base--ul_no-bullets">
+        {Object.keys(Colors).map(c => (<li className="base--li" key={c} style={{
+                backgroundColor: Colors[c],
+                // 8947848 is #888888, converted to decimal - darker
+                color: parseInt(Colors[c].substr(1), 16) > 8947848 ? 'black' : 'white'
+              }}>{c}</li>)
+        )}
+      </ul>
+      <Code language="jsx">{`
+import { Colors } from 'watson-react-components';
+
+export function ColorExample() {
+  return (<div style={{color: Colors.blue_60}}>I'm blue.</div>);
+}
+`}</Code>
     </section>
   );
 }

--- a/example/src/components/ColorsExample.js
+++ b/example/src/components/ColorsExample.js
@@ -7,11 +7,13 @@ export default function ColorsExamples() {
     <section id="Colors">
       <h2 className="base--h2">Colors</h2>
       <ul className="base--ul base--ul_inline base--ul_no-bullets">
-        {Object.keys(Colors).map(c => (<li className="base--li" key={c} style={{
-                backgroundColor: Colors[c],
+        {Object.keys(Colors).map(c => (<li
+          className="base--li" key={c} style={{
+            backgroundColor: Colors[c],
                 // 8947848 is #888888, converted to decimal - darker
-                color: parseInt(Colors[c].substr(1), 16) > 8947848 ? 'black' : 'white'
-              }}>{c}</li>)
+            color: parseInt(Colors[c].substr(1), 16) > 8947848 ? 'black' : 'white',
+          }}
+        >{c}</li>)
         )}
       </ul>
       <Code language="jsx">{`

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -14,7 +14,7 @@ export Modal from './Modal';
 export ArrowBox from './ArrowBox';
 export JsonLink from './JsonLink';
 
-export Colors from './Colors'
+export Colors from './Colors';
 
 export { Icon } from './Icon';
 

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -14,6 +14,8 @@ export Modal from './Modal';
 export ArrowBox from './ArrowBox';
 export JsonLink from './JsonLink';
 
+export Colors from './Colors'
+
 export { Icon } from './Icon';
 
 export { RadioGroup, Radio } from './RadioGroup.js';


### PR DESCRIPTION
I went to use an ArrowBox and first noticed that Colors wasn't exported, so I couldn't just copy the example, and then I realized that I'd have to fiddle around to see what the options were. This fixes both of those.

![screen shot 2017-01-09 at 2 38 03 pm](https://cloud.githubusercontent.com/assets/114976/21780359/4346fe30-d679-11e6-814e-c0d118afe42c.png)
