### PR TITLE
add pre-commit and run npm test on commit hook

### DIFF
--- a/dependency-lint.yml
+++ b/dependency-lint.yml
@@ -46,6 +46,8 @@ ignoreErrors:
     # css dependencies
     - watson-ui-component
 
+    # pre-commit
+    - pre-commit
 requiredModules:
   files:
     dev:

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "gulp-sass": "^3.1.0",
     "gulp-sourcemaps": "^2.2.3",
     "minifyify": "^7.1.0",
+    "pre-commit": "^1.2.2",
     "react-dom": "^15.4.2",
     "uglifyify": "^3.0.2",
     "vinyl-source-stream": "^1.1.0"
@@ -109,5 +110,8 @@
     "react": "^0.14.0 || ^15.3.0",
     "react-dom": "^0.14.0 || ^15.3.0",
     "prismjs": "^1.5.1"
-  }
+  },
+  "pre-commit": [
+    "test"
+  ]
 }


### PR DESCRIPTION
### Summary

Refers to issue #67 , and adds `pre-commit` to devDependencies, as well as a pre-commit test hook that runs `npm test` before any local commit.